### PR TITLE
💯 Fixed : Column width Now Consistent with other columns  

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -191,7 +191,7 @@ article h2 {
   -moz-column-width: 112px;
   -moz-column-gap: 10px;
   column-count: 2;
-  column-width: 117px;
+  column-width: 112px;
   column-gap: 10px; }
 
 .tertiary article:last-of-type {


### PR DESCRIPTION
💯 Fixed : Column width Now Consistent with other columns  #5 

![image](https://github.com/spbooks/htmlcss2/assets/78689154/a47e360d-5f41-40dc-9867-b1e44febdb89)

In your provided CSS code, you've mentioned a specific column width for a .tertiary .content rule on line 194:

```
.tertiary .content {
  -webkit-column-count: 2;
  -webkit-column-width: 112px;
  -webkit-column-gap: 10px;
  -moz-column-count: 2;
  -moz-column-width: 112px;
  -moz-column-gap: 10px;
  column-count: 2;
  column-width: 117px; /* <-- Inconsistency here */
  column-gap: 10px;
}
```

The inconsistency you've identified is correct. The column-width property is set to 117px, which differs from the -webkit-column-width and -moz-column-width values of 112px. If you want consistency, you should adjust the column-width value to match the others. For example, you could change it to:

```
.tertiary .content {
  -webkit-column-count: 2;
  -webkit-column-width: 112px;
  -webkit-column-gap: 10px;
  -moz-column-count: 2;
  -moz-column-width: 112px;
  -moz-column-gap: 10px;
  column-count: 2;
  column-width: 112px; /* <-- Adjusted for consistency */
  column-gap: 10px;
}

```

This will ensure that the column width is consistent across different browsers.





